### PR TITLE
Add missing extern keywords to allow compilation with modern gcc

### DIFF
--- a/src/c_base.c
+++ b/src/c_base.c
@@ -4,6 +4,55 @@
 #include "header/c_cam.h"
 #include "header/m_player.h"
 
+cvar_t	*ban_sword, *ban_chainsaw, *ban_supershotgun,
+		*ban_crossbow,*ban_airgun, *ban_grenadelauncher,
+		*ban_proxylauncher, *ban_rocketlauncher, *ban_hyperblaster,
+		*ban_railgun, *ban_buzzsaw, *ban_vortex, *ban_defenceturret,
+		*ban_rocketturret, *ban_bfg;
+cvar_t	*ban_grapple, *ban_bodyarmor, *ban_combatarmor, *ban_jacketarmor, 
+		*ban_armorshard, *ban_powerscreen, *ban_powershield,
+		*ban_ammo_grenades, *ban_ammo_flashgrenades,
+		*ban_ammo_lasergrenades, *ban_ammo_poisongrenades,
+		*ban_ammo_proximitymines, *ban_ammo_shells,
+		*ban_ammo_explosiveshells, *ban_ammo_arrows,
+		*ban_ammo_explosivearrows, *ban_ammo_poisonarrows,
+		*ban_ammo_cells, *ban_ammo_rockets, *ban_ammo_homingmissiles,
+		*ban_ammo_buzzes, *ban_ammo_slugs, *ban_quaddamage,
+		*ban_jetpack, *ban_invulnerability, *ban_invisibility,
+		*ban_silencer, *ban_rebreather, *ban_environmentsuit,
+		*ban_adrenaline, *ban_health, *ban_health_small,
+		*ban_health_large, *ban_health_mega;
+cvar_t	*start_sword, *start_chainsaw, *start_supershotgun, *start_crossbow,
+		*start_airgun, *start_grenadelauncher, *start_proxylauncher,
+		*start_rocketlauncher, *start_hyperblaster, *start_railgun,
+		*start_buzzsaw, *start_bfg;
+cvar_t	*start_grapple, *start_defenceturret, *start_rocketturret, 
+		*start_autosentry, *start_gravityvortex, *start_bodyarmor,
+		*start_combatarmor, *start_jacketarmor, *start_armorshard,
+		*start_powerscreen, *start_powershield, *start_ammo_grenades,
+		*start_ammo_flashgrenades, *start_ammo_lasergrenades,
+		*start_ammo_poisongrenades, *start_ammo_proximitymines,
+		*start_ammo_shells, *start_ammo_explosiveshells,
+		*start_ammo_arrows, *start_ammo_explosivearrows,
+		*start_ammo_poisonarrows, *start_ammo_cells,
+		*start_ammo_rockets, *start_ammo_homingmissiles,
+		*start_ammo_buzzes, *start_ammo_slugs, *start_quaddamage,
+		*start_jetpack, *start_invulnerability, *start_silencer,
+		*start_rebreather, *start_environmentsuit;
+gitem_t	*it_shells, *it_eshells, *it_cells, *it_arrows, *it_rockets, 
+		*it_homings, *it_slugs, *it_buzzes, *it_grenades,
+		*it_flashgrenades, *it_lasermines, *it_poisongrenades,
+		*it_proxymines, *it_ak42, *it_shotgun, *it_supershotgun,
+		*it_esupershotgun, *it_crossbow, *it_grenadelauncher,
+		*it_rocketlauncher, *it_hominglauncher, *it_railgun,
+		*it_buzzsaw, *it_hyperblaster, *it_bfg,
+		*it_flashgrenadelauncher, *it_poisongrenadelauncher,
+		*it_proxyminelauncher, *it_vortex, *it_sword, *it_rturret,
+		*it_poisonarrows, *it_explosivearrows, *it_poisoncrossbow,
+		*it_explosivecrossbow, *it_grapple, *it_jetpack, *it_chainsaw,
+		*it_health, *it_health_large, *it_health_mega, *it_lturret,
+		*it_airfist;
+
 void Cmd_Say_f (edict_t *ent, qboolean team, qboolean arg0);
 void ClientBeginDeathmatch (edict_t *ent);
 void TossClientWeapon (edict_t *self);

--- a/src/c_botnav.c
+++ b/src/c_botnav.c
@@ -3,6 +3,8 @@
 #include "header/c_botnav.h"
 
 qboolean Bot_CanReachSpotDirectly(edict_t *ent, vec3_t target);
+nodes_t		nodes[MAX_NODES];
+nodeinfo_t	nodeinfo[MAX_NODES];
 
 /*
 Init the note table system

--- a/src/header/c_base.h
+++ b/src/header/c_base.h
@@ -21,7 +21,7 @@ void CameraThink(edict_t *ent, usercmd_t *ucmd);
 
 /* Weapon banning console variables */
 
-cvar_t	*ban_sword, *ban_chainsaw, *ban_supershotgun,
+extern cvar_t	*ban_sword, *ban_chainsaw, *ban_supershotgun,
 		*ban_crossbow,*ban_airgun, *ban_grenadelauncher,
 		*ban_proxylauncher, *ban_rocketlauncher, *ban_hyperblaster,
 		*ban_railgun, *ban_buzzsaw, *ban_vortex, *ban_defenceturret,
@@ -29,7 +29,7 @@ cvar_t	*ban_sword, *ban_chainsaw, *ban_supershotgun,
 
 /* Item banning console variables */
 
-cvar_t	*ban_grapple, *ban_bodyarmor, *ban_combatarmor, *ban_jacketarmor, 
+extern cvar_t	*ban_grapple, *ban_bodyarmor, *ban_combatarmor, *ban_jacketarmor, 
 		*ban_armorshard, *ban_powerscreen, *ban_powershield,
 		*ban_ammo_grenades, *ban_ammo_flashgrenades,
 		*ban_ammo_lasergrenades, *ban_ammo_poisongrenades,
@@ -45,14 +45,14 @@ cvar_t	*ban_grapple, *ban_bodyarmor, *ban_combatarmor, *ban_jacketarmor,
 
 /* Startup weapon console variables */
 
-cvar_t	*start_sword, *start_chainsaw, *start_supershotgun, *start_crossbow,
+extern cvar_t	*start_sword, *start_chainsaw, *start_supershotgun, *start_crossbow,
 		*start_airgun, *start_grenadelauncher, *start_proxylauncher,
 		*start_rocketlauncher, *start_hyperblaster, *start_railgun,
 		*start_buzzsaw, *start_bfg;
 
 /* Startup item console variables */
 
-cvar_t	*start_grapple, *start_defenceturret, *start_rocketturret, 
+extern cvar_t	*start_grapple, *start_defenceturret, *start_rocketturret, 
 		*start_autosentry, *start_gravityvortex, *start_bodyarmor,
 		*start_combatarmor, *start_jacketarmor, *start_armorshard,
 		*start_powerscreen, *start_powershield, *start_ammo_grenades,
@@ -68,7 +68,7 @@ cvar_t	*start_grapple, *start_defenceturret, *start_rocketturret,
 
 /* Item definitions */
 
-gitem_t	*it_shells, *it_eshells, *it_cells, *it_arrows, *it_rockets, 
+extern gitem_t	*it_shells, *it_eshells, *it_cells, *it_arrows, *it_rockets, 
 		*it_homings, *it_slugs, *it_buzzes, *it_grenades,
 		*it_flashgrenades, *it_lasermines, *it_poisongrenades,
 		*it_proxymines, *it_ak42, *it_shotgun, *it_supershotgun,

--- a/src/header/c_botai.h
+++ b/src/header/c_botai.h
@@ -38,8 +38,8 @@
 #define	NUM_CHATSECTIONS		4
 #define	MAX_LINES_PER_SECTION		64
 
-char	*chat_text[NUM_CHATSECTIONS][MAX_LINES_PER_SECTION];
-int		chat_linecount[NUM_CHATSECTIONS];
+extern char	*chat_text[NUM_CHATSECTIONS][MAX_LINES_PER_SECTION];
+extern int		chat_linecount[NUM_CHATSECTIONS];
  
 /* Quake 2 functions */
 void SelectSpawnPoint(edict_t *ent, vec3_t origin, vec3_t angles);

--- a/src/header/c_botnav.h
+++ b/src/header/c_botnav.h
@@ -42,8 +42,8 @@ typedef struct
 } nodes_t;
 
 
-nodes_t		nodes[MAX_NODES];
-nodeinfo_t	nodeinfo[MAX_NODES];
+extern nodes_t		nodes[MAX_NODES];
+extern nodeinfo_t	nodeinfo[MAX_NODES];
 
 
 /* functions */

--- a/src/header/g_local.h
+++ b/src/header/g_local.h
@@ -1,5 +1,8 @@
 /* g_local.h -- local definitions for game module */
 
+#ifndef G_LOCAL_INCLUDE
+#define G_LOCAL_INCLUDE
+
 #include "q_shared.h"
 
 /* define GAME_INCLUDE so that game.h does not define the */
@@ -521,8 +524,8 @@ extern	cvar_t	*bob_roll;
 extern	cvar_t	*sv_cheats;
 extern	cvar_t	*maxclients;
 
-qboolean	is_quad;     /* MATTHIAS */
-byte		is_silenced;
+extern qboolean	is_quad;     /* MATTHIAS */
+extern byte		is_silenced;
 
 #define world	(&g_edicts[0])
 
@@ -1116,12 +1119,12 @@ void	nprintf (int printlevel, char *fmt, ...);
 void	stuffcmd(edict_t *ent, char *s);
 qboolean visible2 (vec3_t spot1, vec3_t spot2);
 void	EndDMLevel (void);
-int		numbots;
-int		numnodes;
-int		numred;	/* size of the red team */
-int		numblue;	/* size of the blue team */
-int		numturrets;
-int		vortexstate;
+extern int		numbots;
+extern int		numnodes;
+extern int		numred;	/* size of the red team */
+extern int		numblue;	/* size of the blue team */
+extern int		numturrets;
+extern int		vortexstate;
 
 #define MAX_MAPS           64 
 #define MAX_MAPNAME_LEN    32
@@ -1140,38 +1143,39 @@ typedef struct
 	int		currentmap;
 } maplist_t;
 
-maplist_t maplist;
+extern maplist_t maplist;
 
-char	motd[570];
-int		numplayers;
-int		path_buffer[100];				/* used to exchange path infos between functions */
+extern char	motd[570];
+extern int numplayers;
+extern int		path_buffer[100];				/* used to exchange path infos between functions */
 										/* dirty but fast way of doing this */
-int		first_pathnode;
-edict_t *players[MAX_CLIENTS];
+extern int		first_pathnode;
+extern edict_t *players[MAX_CLIENTS];
 /* edict_t *turrets[2];	// maximum of 3 turrets */
-edict_t *turrets[4];	/* maximum of 3 turrets FWP - Source of turret crash, need 3 elements for 3 turrets :)*/
-edict_t	*weapon_list;
-edict_t	*health_list;
-edict_t	*powerup_list;
-edict_t	*ammo_list;
-edict_t	*vortex_pointer;	/* pointer to the vortex if one is currently active */
-cvar_t	*node_debug;
-cvar_t	*lightsoff;
-cvar_t	*botchat;
-cvar_t	*blindtime;
-cvar_t	*poisontime;
-cvar_t	*lasertime;
-cvar_t	*proxytime;
-cvar_t	*defence_turret_ammo;
-cvar_t	*rocket_turret_ammo;
-cvar_t	*dntg;
-cvar_t	*lasermine_health;
-cvar_t	*ex_arrow_damage;
-cvar_t	*ex_arrow_radius;
-cvar_t	*cosg; /* FWP Debugging var, core on shutdown game */
+extern edict_t *turrets[4];	/* maximum of 3 turrets FWP - Source of turret crash, need 3 elements for 3 turrets :)*/
+extern edict_t	*weapon_list;
+extern edict_t	*health_list;
+extern edict_t	*powerup_list;
+extern edict_t	*ammo_list;
+extern edict_t	*vortex_pointer;	/* pointer to the vortex if one is currently active */
+extern cvar_t	*node_debug;
+extern cvar_t	*lightsoff;
+extern cvar_t	*botchat;
+extern cvar_t	*blindtime;
+extern cvar_t	*poisontime;
+extern cvar_t	*lasertime;
+extern cvar_t	*proxytime;
+extern cvar_t	*defence_turret_ammo;
+extern cvar_t	*rocket_turret_ammo;
+extern cvar_t	*dntg;
+extern cvar_t	*lasermine_health;
+extern cvar_t	*ex_arrow_damage;
+extern cvar_t	*ex_arrow_radius;
+extern cvar_t	*cosg; /* FWP Debugging var, core on shutdown game */
 
-cvar_t	*start_invulnerable_time;
-int		red_base, blue_base;	/* node at red/blue flag */
+extern cvar_t	*start_invulnerable_time;
+extern int red_base;
+extern int blue_base;	/* node at red/blue flag */
 
 /* #define CHAOS_RETAIL */
 
@@ -1182,4 +1186,6 @@ int		red_base, blue_base;	/* node at red/blue flag */
 #define UNUSEDVAR __attribute__((unused))
 #else
 #define UNUSEDVAR
+#endif
+
 #endif

--- a/src/p_client.c
+++ b/src/p_client.c
@@ -8,7 +8,9 @@
 #include "header/stdlog.h"
 #include "header/gslog.h"
 
-
+char	*chat_text[NUM_CHATSECTIONS][MAX_LINES_PER_SECTION];
+int		chat_linecount[NUM_CHATSECTIONS];
+ 
 void ClientUserinfoChanged (edict_t *ent, char *userinfo);
 void SP_misc_teleporter_dest (edict_t *ent);
 

--- a/src/p_hud.c
+++ b/src/p_hud.c
@@ -1,6 +1,47 @@
 #include "header/g_local.h"
 #include "header/c_base.h"
 
+int		numbots;
+int		numnodes;
+int		numred;
+int		numblue;
+int		numturrets;
+int		vortexstate;
+
+maplist_t maplist;
+
+char	motd[570];
+int numplayers;
+int		path_buffer[100];				/* used to exchange path infos between functions */
+										/* dirty but fast way of doing this */
+int		first_pathnode;
+edict_t *players[MAX_CLIENTS];
+/* edict_t *turrets[2];	// maximum of 3 turrets */
+edict_t *turrets[4];	/* maximum of 3 turrets FWP - Source of turret crash, need 3 elements for 3 turrets :)*/
+edict_t	*weapon_list;
+edict_t	*health_list;
+edict_t	*powerup_list;
+edict_t	*ammo_list;
+edict_t	*vortex_pointer;	/* pointer to the vortex if one is currently active */
+cvar_t	*node_debug;
+cvar_t	*lightsoff;
+cvar_t	*botchat;
+cvar_t	*blindtime;
+cvar_t	*poisontime;
+cvar_t	*lasertime;
+cvar_t	*proxytime;
+cvar_t	*defence_turret_ammo;
+cvar_t	*rocket_turret_ammo;
+cvar_t	*dntg;
+cvar_t	*lasermine_health;
+cvar_t	*ex_arrow_damage;
+cvar_t	*ex_arrow_radius;
+cvar_t	*cosg; /* FWP Debugging var, core on shutdown game */
+
+cvar_t	*start_invulnerable_time;
+int red_base;
+int blue_base;
+
 void Bot_Respawn(edict_t *ent);
 qboolean Jet_Active( edict_t *ent );
 void ShowScanner(edict_t *ent,char *layout);

--- a/src/p_weapon.c
+++ b/src/p_weapon.c
@@ -5,6 +5,9 @@
 #include "header/c_base.h"
 #include "header/c_botai.h"
 
+qboolean	is_quad;     /* MATTHIAS */
+byte		is_silenced;
+
 void weapon_grenade_fire (edict_t *ent, qboolean held);
 
 


### PR DESCRIPTION
Ever since GCC10, -fno-common has become a default, which breaks compilation for sources with missing extern keywords for global definitions. (See: https://gcc.gnu.org/gcc-10/porting_to.html ).
ChaosDM has a bunch of those missing, hence it's failing to compile with modern versions of gcc. 

With this patch, I was able to get it built using gcc 12.